### PR TITLE
filtering, documentation, testing

### DIFF
--- a/helpers/sql.test.js
+++ b/helpers/sql.test.js
@@ -28,7 +28,7 @@ describe("sqlForPartialUpdate", function () {
         expect(values).toEqual(["Sarah", "Michaels", "sarah", "email@email.com", true]);
     });
 
-    test("no data error", function () {
+    test("error no data", function () {
         const inputData = {};
         const sqlFormat = { firstName: "first_name" };
         expect(() => {

--- a/models/company.test.js
+++ b/models/company.test.js
@@ -85,6 +85,174 @@ describe("findAll", function () {
       },
     ]);
   });
+
+  test("works: empty filter object", async function () {
+    let filter = {}
+    let companies = await Company.findAll(filter);
+    expect(companies).toEqual([
+      {
+        handle: "c1",
+        name: "C1",
+        description: "Desc1",
+        numEmployees: 1,
+        logoUrl: "http://c1.img",
+      },
+      {
+        handle: "c2",
+        name: "C2",
+        description: "Desc2",
+        numEmployees: 2,
+        logoUrl: "http://c2.img",
+      },
+      {
+        handle: "c3",
+        name: "C3",
+        description: "Desc3",
+        numEmployees: 3,
+        logoUrl: "http://c3.img",
+      },
+    ]);
+  });
+
+  test("error min greater than max", async function () {
+    expect(async () => {
+      await Company.findAll({ minEmployees: 100, maxEmployees: 20 });
+    }).rejects.toThrow();
+  });
+
+  test("works: name filter", async function () {
+    let filter = {
+      nameLike: "2"
+    }
+    let companies = await Company.findAll(filter);
+    expect(companies).toEqual([
+      {
+        handle: "c2",
+        name: "C2",
+        description: "Desc2",
+        numEmployees: 2,
+        logoUrl: "http://c2.img",
+      }
+    ]);
+  });
+
+  test("works: name filter case insensitive", async function () {
+    let filter = {
+      nameLike: "c"
+    }
+    let companies = await Company.findAll(filter);
+    expect(companies).toEqual([
+      {
+        handle: "c1",
+        name: "C1",
+        description: "Desc1",
+        numEmployees: 1,
+        logoUrl: "http://c1.img",
+      },
+      {
+        handle: "c2",
+        name: "C2",
+        description: "Desc2",
+        numEmployees: 2,
+        logoUrl: "http://c2.img",
+      },
+      {
+        handle: "c3",
+        name: "C3",
+        description: "Desc3",
+        numEmployees: 3,
+        logoUrl: "http://c3.img",
+      },
+    ]);
+  });
+
+  test("works: min employees filter", async function () {
+    let filter = {
+      minEmployees: 2
+    }
+    let companies = await Company.findAll(filter);
+    expect(companies).toEqual([
+      {
+        handle: "c2",
+        name: "C2",
+        description: "Desc2",
+        numEmployees: 2,
+        logoUrl: "http://c2.img",
+      },
+      {
+        handle: "c3",
+        name: "C3",
+        description: "Desc3",
+        numEmployees: 3,
+        logoUrl: "http://c3.img",
+      }
+    ]);
+  });
+
+  test("works: max employees filter", async function () {
+    let filter = {
+      maxEmployees: 2
+    }
+    let companies = await Company.findAll(filter);
+    expect(companies).toEqual([
+      {
+        handle: "c1",
+        name: "C1",
+        description: "Desc1",
+        numEmployees: 1,
+        logoUrl: "http://c1.img",
+      },
+      {
+        handle: "c2",
+        name: "C2",
+        description: "Desc2",
+        numEmployees: 2,
+        logoUrl: "http://c2.img",
+      }
+    ]);
+  });
+
+  test("works: min and max employees filter", async function () {
+    let filter = {
+      minEmployees: 1,
+      maxEmployees: 2
+    }
+    let companies = await Company.findAll(filter);
+    expect(companies).toEqual([
+      {
+        handle: "c1",
+        name: "C1",
+        description: "Desc1",
+        numEmployees: 1,
+        logoUrl: "http://c1.img",
+      },
+      {
+        handle: "c2",
+        name: "C2",
+        description: "Desc2",
+        numEmployees: 2,
+        logoUrl: "http://c2.img",
+      }
+    ]);
+  });
+
+  test("works: min, max and name filter", async function () {
+    let filter = {
+      nameLike: "1",
+      minEmployees: 1,
+      maxEmployees: 2
+    }
+    let companies = await Company.findAll(filter);
+    expect(companies).toEqual([
+      {
+        handle: "c1",
+        name: "C1",
+        description: "Desc1",
+        numEmployees: 1,
+        logoUrl: "http://c1.img",
+      }
+    ]);
+  });
 });
 
 /************************************** get */

--- a/routes/companies.js
+++ b/routes/companies.js
@@ -14,6 +14,8 @@ const companyUpdateSchema = require("../schemas/companyUpdate.json");
 
 const router = new express.Router();
 
+const authorizedFilters = ["nameLike", "minEmployees", "maxEmployees"];
+
 
 /** POST / { company } =>  { company }
  *
@@ -52,7 +54,14 @@ router.post("/", ensureLoggedIn, async function (req, res, next) {
 
 router.get("/", async function (req, res, next) {
   try {
-    const companies = await Company.findAll();
+    let filters = {};
+    for (const each in req.body) {
+      if (!authorizedFilters.includes(each)) {
+        throw new BadRequestError("Invalid filter: " + each);
+      }
+      filters[each] = req.body[each];
+    }
+    const companies = await Company.findAll(filters);
     return res.json({ companies });
   } catch (err) {
     return next(err);

--- a/routes/companies.test.js
+++ b/routes/companies.test.js
@@ -96,6 +96,84 @@ describe("GET /companies", function () {
     });
   });
 
+  test("works: empty filter", async function () {
+    const resp = await request(app).get("/companies").send({});
+    expect(resp.body).toEqual({
+      companies:
+          [
+            {
+              handle: "c1",
+              name: "C1",
+              description: "Desc1",
+              numEmployees: 1,
+              logoUrl: "http://c1.img",
+            },
+            {
+              handle: "c2",
+              name: "C2",
+              description: "Desc2",
+              numEmployees: 2,
+              logoUrl: "http://c2.img",
+            },
+            {
+              handle: "c3",
+              name: "C3",
+              description: "Desc3",
+              numEmployees: 3,
+              logoUrl: "http://c3.img",
+            },
+          ],
+    });
+  });
+
+  test("works: name filter", async function () {
+    const resp = await request(app).get("/companies").send({ nameLike: "2" });
+    expect(resp.body).toEqual({
+      companies:
+          [
+            {
+              handle: "c2",
+              name: "C2",
+              description: "Desc2",
+              numEmployees: 2,
+              logoUrl: "http://c2.img",
+            }
+          ],
+    });
+  });
+
+  test("works: min and max employees filter", async function () {
+    const resp = await request(app).get("/companies").send({
+      minEmployees: 1,
+      maxEmployees: 2
+    });
+    expect(resp.body).toEqual({
+      companies:
+          [
+            {
+              handle: "c1",
+              name: "C1",
+              description: "Desc1",
+              numEmployees: 1,
+              logoUrl: "http://c1.img",
+            },
+            {
+              handle: "c2",
+              name: "C2",
+              description: "Desc2",
+              numEmployees: 2,
+              logoUrl: "http://c2.img",
+            }
+          ],
+    });
+  });
+
+  test("fails: invalid filter", async function () {
+    const resp = await request(app).get("/companies").send({ strong: true });
+    expect(resp.statusCode).toBe(400);
+  });
+
+
   test("fails: test next() handler", async function () {
     // there's no normal failure event which will cause this route to fail ---
     // thus making it hard to test that the error-handler works with it. This


### PR DESCRIPTION
### **Adding Filtering**

The route for listing all companies (***GET /companies***) works, but it currently shows all companies. Add a new feature to this, allowing API users to filter the results based on optional filtering criteria, any or all of which can be passed in the query string:

- ***name***: filter by company name: if the string “net” is passed in, this should find any company who name contains the word “net”, case-insensitive (so “Study Networks” should be included).
- ***minEmployees***: filter to companies that have at least that number of employees.
- ***maxEmployees***: filter to companies that have no more than that number of employees.
- If the ***minEmployees*** parameter is greater than the ***maxEmployees*** parameter, respond with a 400 error with an appropriate message.

**Some requirements:**

- Do not solve this by issuing a more complex SELECT statement than is needed (for example, if the user isn’t filtering by ***minEmployees*** or ***maxEmployees***, the SELECT statement should not include anything about the ***num_employees***.
- Validate that the request does not contain inappropriate other filtering fields in the route. Do the actual filtering in the model.
- Write unit tests for the model that exercise this in different ways, so you can be assured different combinations of filtering will work.
    
    Write tests for the route that will ensure that it correctly validates the incoming request and uses the model method properly.
    
- Document all new code here clearly; this is functionality that future team members should be able to understand how to use from your docstrings.